### PR TITLE
fix(aws-actions): update aws actions to v4

### DIFF
--- a/.github/workflows/deploy-xplorers-bot.yml
+++ b/.github/workflows/deploy-xplorers-bot.yml
@@ -1,9 +1,9 @@
 name: Deploy Xplorers Bot to AWS
 
-on: push
-  # push:
-  #   branches:
-  #     - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   deploy-xplorers-bot-to-aws:

--- a/.github/workflows/deploy-xplorers-bot.yml
+++ b/.github/workflows/deploy-xplorers-bot.yml
@@ -1,9 +1,9 @@
 name: Deploy Xplorers Bot to AWS
 
-on:
-  push:
-    branches:
-      - main
+on: push
+  # push:
+  #   branches:
+  #     - main
 
 jobs:
   deploy-xplorers-bot-to-aws:
@@ -25,7 +25,7 @@ jobs:
       uses: hashicorp/setup-terraform@v2
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN_FOR_GITHUB_ACTIONS }}
         aws-region: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
### [AWS Actions v3 no longer works as its not able to read org secrets](https://github.com/xplorer-io/xplorers-bot-ts-aws/actions/runs/7914275779)
<img width="1726" alt="image" src="https://github.com/xplorer-io/xplorers-bot-ts-aws/assets/42393225/3e358c6a-76f6-4901-9ff0-880a5f9bf445">

### [Working actions run](https://github.com/xplorer-io/xplorers-bot-ts-aws/actions/runs/7922069143/job/21628805299)
<img width="1725" alt="image" src="https://github.com/xplorer-io/xplorers-bot-ts-aws/assets/42393225/e0354173-202a-455b-9db2-edae95bea627">
